### PR TITLE
chore: bump agynd to v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM alpine:3.21
 
-ARG AGYND_VERSION=0.3.0
+ARG AGYND_VERSION
 ARG CODEX_VERSION
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
- bump agynd version default to v0.3.0
- update versions.env to v0.3.0

## Testing
- Not run (no tests or lint configured)

Closes #4