### PR TITLE
fix: config.json belongs at /agyn, and restore the pinned Codex version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ COPY config.json /opt/agyn/config.json
 # compose without coordinating beyond the layout. Running as root is required:
 # the emptyDir is root-owned on a fresh Pod. The copied files are world-readable
 # so the main container can use them whatever user its image defines.
-ENTRYPOINT ["/bin/sh", "-c", "set -e; mkdir -p /agyn/bin; cp /opt/agyn/codex /agyn/bin/codex; chmod 0755 /agyn/bin/codex; cp /opt/agyn/config.json /agyn/bin/config.json; chmod 0644 /agyn/bin/config.json"]
+ENTRYPOINT ["/bin/sh", "-c", "set -e; mkdir -p /agyn/bin; cp /opt/agyn/codex /agyn/bin/codex; chmod 0755 /agyn/bin/codex; cp /opt/agyn/config.json /agyn/config.json; chmod 0644 /agyn/config.json"]

--- a/VERSION
+++ b/VERSION
@@ -2,4 +2,4 @@
 # among its contents, so bumping one agent CLI rebuilds nothing else.
 #
 # Upstream tags releases rust-v<version>; this is the <version> part.
-CODEX_VERSION=0.146.0
+CODEX_VERSION=0.116.0


### PR DESCRIPTION
Two fixes.

`config.json` goes to `/agyn/config.json`, not `/agyn/bin/config.json` — [agent-init.md](https://github.com/agynio/architecture/blob/main/architecture/agent-init.md) puts binaries under `/agyn/bin` and the runtime's config beside them.

The Codex pin also moved unintentionally: replacing `versions.env` with `VERSION` carried `0.146.0` from a draft rather than the `0.116.0` in use, a thirty-minor-version upgrade nobody asked for. Restored.