### PR TITLE
State the CLI relative to the volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ its tags mean something in a version picker.
 ```
 /agyn/bin/
 ├── codex          # the agent CLI
-└── config.json    # {"sdk": "codex", "bin": "/agyn/bin/codex"}
+└── config.json    # {"sdk": "codex", "bin": "bin/codex"}
 ```
 
 `agynd` reads `config.json` at startup to learn which SDK module to use and

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
   "sdk": "codex",
-  "bin": "/agyn/bin/codex"
+  "bin": "bin/codex"
 }


### PR DESCRIPTION
An absolute `bin` asserts where the platform mounted the volume; the image only knows what it carries. agynd resolves it against the mount and now rejects an absolute value.